### PR TITLE
Poke object property access

### DIFF
--- a/src/games/poke-shooter/scenes/MainScene.js
+++ b/src/games/poke-shooter/scenes/MainScene.js
@@ -51,8 +51,12 @@ export default class MainScene extends Phaser.Scene {
         });
 
         this.pokemons.children.each(poke => {
+            // Group iteration can include destroyed/null entries depending on timing;
+            // guard before accessing position/properties.
+            if (!poke || !poke.active) return;
+
             // Keep UI hearts following the pokemon sprite
-            if (poke && poke.hearts && poke.active) {
+            if (poke.hearts) {
                 const gap = 20;
                 const startXHeart = -((poke.maxHp - 1) * gap) / 2;
                 for (let i = 0; i < poke.hearts.length; i++) {


### PR DESCRIPTION
Add null/active guard for `poke` in the pokemon iteration loop to prevent crashes during off-screen cleanup.

Previously, `poke.x` and `poke.y` were accessed without guards for off-screen cleanup, despite other parts of the loop (like heart tracking) checking for `poke`'s validity. This could lead to crashes if `poke` was null, undefined, or inactive.

---
<a href="https://cursor.com/background-agent?bcId=bc-c48775f8-014d-4e02-a527-1596f18da671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c48775f8-014d-4e02-a527-1596f18da671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents runtime errors when iterating `pokemons` by guarding against destroyed/null entries and relying on that guard for UI updates.
> 
> - Add `if (!poke || !poke.active) return;` in `update()` group iteration to avoid accessing invalid sprites
> - Simplify heart-follow condition from `poke && poke.hearts && poke.active` to `poke.hearts` under the new guard
> - Add inline comment clarifying timing-related null/destroyed cases in group iteration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c61c7ad9bdbf4bb81bd84411a90a9ef6f2b8d9be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->