### PR TITLE
Game screen adjustments

### DIFF
--- a/src/games/poke-shooter/scenes/MainScene.js
+++ b/src/games/poke-shooter/scenes/MainScene.js
@@ -7,13 +7,11 @@ export default class MainScene extends Phaser.Scene {
     }
 
     create() {
-        // Background
-        const bg = this.add.image(this.scale.width / 2, this.scale.height / 2, 'background');
-        // Scale background to cover screen
-        const scaleX = this.scale.width / bg.width;
-        const scaleY = this.scale.height / bg.height;
-        const scale = Math.max(scaleX, scaleY);
-        bg.setScale(scale).setScrollFactor(0);
+        // Background (fit to current game size, and keep fitting on resize)
+        this.bg = this.add.image(this.scale.width / 2, this.scale.height / 2, 'background');
+        this.bg.setScrollFactor(0);
+        this.fitBackgroundToScreen();
+        this.scale.on('resize', this.fitBackgroundToScreen, this);
 
         // Groups
         this.balls = this.physics.add.group();
@@ -40,6 +38,21 @@ export default class MainScene extends Phaser.Scene {
         const height = this.scale.height;
         this.playerPos = new Phaser.Math.Vector2(width / 2, height - 70);
         this.add.circle(this.playerPos.x, this.playerPos.y, 10, 0xffffff);
+    }
+
+    fitBackgroundToScreen(gameSize) {
+        if (!this.bg || !this.bg.active) return;
+
+        const width = gameSize?.width ?? this.scale.width;
+        const height = gameSize?.height ?? this.scale.height;
+
+        this.bg.setPosition(width / 2, height / 2);
+
+        // Cover the whole screen (no gaps). Keeps aspect ratio; may crop edges slightly.
+        const scaleX = width / this.bg.width;
+        const scaleY = height / this.bg.height;
+        const scale = Math.max(scaleX, scaleY);
+        this.bg.setScale(scale);
     }
 
     update() {
@@ -164,16 +177,17 @@ export default class MainScene extends Phaser.Scene {
     catchPokemon(poke) {
         // Particles - One shot
         const particles = this.add.particles(poke.x, poke.y, 'monster_ball', {
-            speed: { min: 100, max: 300 },
-            scale: { start: 0.1, end: 0 },
+            speed: { min: 160, max: 480 },
+            // Make the effect clearly visible on mobile/high-DPI screens
+            scale: { start: 0.28, end: 0 },
             alpha: { start: 1, end: 0 },
-            lifespan: 600,
-            quantity: 20,
+            lifespan: 700,
+            quantity: 28,
             blendMode: 'ADD',
             emitting: false
         });
 
-        particles.explode(20);
+        particles.explode(28);
 
         // Score & Collection
         this.events.emit('pokemonCaught', poke.pokemonId);


### PR DESCRIPTION
Adjust background image scaling and monster ball collision effect size.

The background image was not fitting the game screen, and the monster ball collision effect was too small to be seen, especially on high-DPI screens. This PR ensures the background fits the canvas and resizes dynamically, and increases the particle scale and quantity for the collision effect.

---
<a href="https://cursor.com/background-agent?bcId=bc-ff7fe27d-e878-42da-8b48-61ccdedbf959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ff7fe27d-e878-42da-8b48-61ccdedbf959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures the game background fully covers the canvas across sizes and improves the visibility of the capture effect.
> 
> - Add `fitBackgroundToScreen` and store background as `this.bg`; re-position/scale on create and on `scale.resize` to always cover the screen
> - Increase capture particle impact: higher speed range, larger start `scale`, longer `lifespan`, greater `quantity`, and `explode(28)` in `catchPokemon`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7dadfecede4d8e8b27259c1320ec4ddd78775870. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->