### PR TITLE
feat(star-runner): タブレット向けタッチ操作を追加

### DIFF
--- a/src/games/star-runner/game.js
+++ b/src/games/star-runner/game.js
@@ -80,6 +80,38 @@ document.addEventListener('keyup', (e) => {
   if (keyMap[e.code]) input[keyMap[e.code]] = false;
 });
 
+function bindHoldControl(button, key) {
+  if (!button) return;
+  const start = (e) => {
+    e.preventDefault();
+    input[key] = true;
+  };
+  const end = (e) => {
+    e.preventDefault();
+    input[key] = false;
+  };
+  button.addEventListener('pointerdown', start);
+  button.addEventListener('pointerup', end);
+  button.addEventListener('pointercancel', end);
+  button.addEventListener('pointerleave', end);
+}
+
+function setupTouchControls() {
+  const leftButton = document.querySelector('[data-control="left"]');
+  const rightButton = document.querySelector('[data-control="right"]');
+  const jumpButton = document.querySelector('[data-control="jump"]');
+
+  bindHoldControl(leftButton, 'left');
+  bindHoldControl(rightButton, 'right');
+
+  if (jumpButton) {
+    jumpButton.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      input.jumpPressed = true;
+    });
+  }
+}
+
 function resetGame() {
   player.x = 80;
   player.y = 350;
@@ -90,7 +122,7 @@ function resetGame() {
   player.invincibleFrames = 0;
   collectedCoins = new Set();
   gameState = 'playing';
-  messageLabel.textContent = '→ と ← で移動 / スペースでジャンプ';
+  messageLabel.textContent = '→ と ← で移動 / スペース or タッチでジャンプ';
   updateHud();
 }
 
@@ -301,6 +333,8 @@ function loop() {
   drawOverlay();
   requestAnimationFrame(loop);
 }
+
+setupTouchControls();
 
 updateHud();
 loop();

--- a/src/games/star-runner/index.html
+++ b/src/games/star-runner/index.html
@@ -13,12 +13,19 @@
       <div class="hud-stats">
         <span id="coinLabel">コイン: 0 / 0</span>
         <span id="lifeLabel">ライフ: 3</span>
-        <span id="messageLabel">→ と ← で移動 / スペースでジャンプ</span>
+        <span id="messageLabel">→ と ← で移動 / スペース or タッチでジャンプ</span>
       </div>
     </header>
     <canvas id="gameCanvas" width="960" height="540" aria-label="横スクロールアクションゲーム"></canvas>
+    <section class="touch-controls" aria-label="タッチ操作">
+      <div class="touch-controls__move">
+        <button type="button" class="touch-btn" data-control="left" aria-label="左に移動">←</button>
+        <button type="button" class="touch-btn" data-control="right" aria-label="右に移動">→</button>
+      </div>
+      <button type="button" class="touch-btn touch-btn--jump" data-control="jump" aria-label="ジャンプ">ジャンプ</button>
+    </section>
     <footer class="tips">
-      <p>操作: ← → で移動 / スペース or ↑ でジャンプ / R でリスタート</p>
+      <p>操作: ← → で移動 / スペース or ↑ でジャンプ / タッチボタン対応 / R でリスタート</p>
     </footer>
   </main>
 

--- a/src/games/star-runner/style.css
+++ b/src/games/star-runner/style.css
@@ -62,15 +62,69 @@ body {
   background: #1e293b;
 }
 
+
+.touch-controls {
+  display: none;
+  margin-top: 10px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.touch-controls__move {
+  display: flex;
+  gap: 10px;
+}
+
+.touch-btn {
+  min-width: 64px;
+  min-height: 56px;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  font-size: 1.25rem;
+  font-weight: 700;
+  touch-action: manipulation;
+}
+
+.touch-btn:active {
+  transform: scale(0.96);
+  background: rgba(30, 41, 59, 0.95);
+}
+
+.touch-btn--jump {
+  min-width: 110px;
+  font-size: 1rem;
+}
+
 .tips {
   text-align: center;
   color: #cbd5e1;
   font-size: 0.9rem;
 }
 
+@media (max-width: 1024px) {
+  .touch-controls {
+    display: flex;
+  }
+}
+
 @media (max-width: 720px) {
   .hud {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .touch-controls {
+    width: 100%;
+  }
+
+  .touch-btn {
+    min-height: 52px;
+  }
+
+  .touch-btn--jump {
+    margin-left: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- スターランナーをタブレットでも快適に遊べるように、画面上のタッチ操作ボタンを追加するための変更です。
- 既存のキーボード操作は維持して、タッチデバイスでの操作を補完することが目的です。
- タブレット向けにレスポンシブに表示されるシンプルな操作UIを提供します。

### Description
- 追加でタッチUIのマークアップを `src/games/star-runner/index.html` に追加し、左右移動ボタンとジャンプボタンを配置しました.
- `src/games/star-runner/style.css` にタッチボタンのスタイルと `@media (max-width: 1024px)` のレスポンシブ表示ルールを追加しました.
- `src/games/star-runner/game.js` に `bindHoldControl` と `setupTouchControls` を実装し、`pointer` イベントで左右の押しっぱなし移動とジャンプの発火を処理するようにしました.
- ヘッダーとフッタの操作案内文言をタッチ対応に更新し、初期化時に `setupTouchControls()` を呼び出すようにしました.

### Testing
- `npm run build` を実行してビルドが成功することを確認しました（ビルド成功）。
- 開発サーバーを `npm run dev -- --host 0.0.0.0 --port 4173` で起動してページが配信されることを確認しました（起動成功）。
- Playwright スクリプトで `http://127.0.0.1:4173/games/star-runner/` をタブレット相当のビューポート (`1024x1366`) で開いてスクリーンショットを取得し、タッチUIが表示されることを確認しました（スクリーンショット取得成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699969a7a5b483219ba1aa22b92fea65)