### PR TITLE
feat: Supabase が落ちててもオフラインで遊べるようにする

### DIFF
--- a/src/js/offline.js
+++ b/src/js/offline.js
@@ -1,0 +1,136 @@
+// Offline fallback helpers.
+// Supabase が落ちている時でも、家族のプレイヤー情報やスコアをローカルで使えるようにする。
+
+export const LOCAL_PLAYERS_KEY = 'n-games-players-local';
+export const LOCAL_SCORES_KEY = 'n-games-scores-local';
+
+let offlineNoticeShown = false;
+
+export function genLocalId() {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  return `local_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+export function loadLocalPlayers() {
+  try {
+    const raw = localStorage.getItem(LOCAL_PLAYERS_KEY);
+    const list = raw ? JSON.parse(raw) : [];
+    return Array.isArray(list) ? list : [];
+  } catch {
+    return [];
+  }
+}
+
+export function saveLocalPlayers(list) {
+  try {
+    localStorage.setItem(LOCAL_PLAYERS_KEY, JSON.stringify(list || []));
+  } catch (e) {
+    console.warn('saveLocalPlayers failed:', e);
+  }
+}
+
+export function getLocalPlayerById(id) {
+  return loadLocalPlayers().find((p) => p.id === id) || null;
+}
+
+export function loadLocalScores() {
+  try {
+    const raw = localStorage.getItem(LOCAL_SCORES_KEY);
+    const obj = raw ? JSON.parse(raw) : {};
+    return obj && typeof obj === 'object' ? obj : {};
+  } catch {
+    return {};
+  }
+}
+
+export function saveLocalScoresMap(map) {
+  try {
+    localStorage.setItem(LOCAL_SCORES_KEY, JSON.stringify(map || {}));
+  } catch (e) {
+    console.warn('saveLocalScoresMap failed:', e);
+  }
+}
+
+export function appendLocalScore(gameId, playerId, score) {
+  if (!gameId) return;
+  const map = loadLocalScores();
+  const arr = Array.isArray(map[gameId]) ? map[gameId] : [];
+  arr.push({
+    player_id: playerId,
+    score: Number(score) || 0,
+    created_at: new Date().toISOString()
+  });
+  arr.sort((a, b) => (b.score || 0) - (a.score || 0));
+  map[gameId] = arr.slice(0, 50);
+  saveLocalScoresMap(map);
+}
+
+export function localRankings(gameId, limit = 5) {
+  const map = loadLocalScores();
+  const arr = Array.isArray(map[gameId]) ? map[gameId].slice() : [];
+  arr.sort((a, b) => (b.score || 0) - (a.score || 0));
+  const players = new Map(loadLocalPlayers().map((p) => [p.id, p]));
+  return arr.slice(0, limit).map((item) => {
+    const p = players.get(item.player_id);
+    return {
+      score: item.score,
+      name: p?.name || 'プレイヤー',
+      avatar: p?.avatar || '❓',
+      date: new Date(item.created_at).toLocaleDateString()
+    };
+  });
+}
+
+/**
+ * 画面右上にオフライン通知を一度だけ出す。
+ * @param {string} [message]
+ */
+export function showOfflineNotice(message = 'オフラインモードで動作中（データはこの端末にだけ保存されます）') {
+  if (offlineNoticeShown) return;
+  offlineNoticeShown = true;
+  if (typeof document === 'undefined') return;
+
+  const ensure = () => {
+    if (!document.body) {
+      document.addEventListener('DOMContentLoaded', ensure, { once: true });
+      return;
+    }
+    const el = document.createElement('div');
+    el.textContent = message;
+    el.setAttribute('role', 'status');
+    el.style.cssText = [
+      'position:fixed',
+      'top:12px',
+      'left:50%',
+      'transform:translateX(-50%)',
+      'z-index:99999',
+      'background:rgba(255, 165, 0, 0.95)',
+      'color:#3a2200',
+      'padding:8px 14px',
+      'border-radius:999px',
+      'font-size:0.85rem',
+      'font-weight:bold',
+      'box-shadow:0 4px 14px rgba(0,0,0,0.2)',
+      'max-width:calc(100vw - 24px)',
+      'text-align:center',
+      'pointer-events:none'
+    ].join(';');
+    document.body.appendChild(el);
+    setTimeout(() => {
+      el.style.transition = 'opacity 600ms';
+      el.style.opacity = '0';
+      setTimeout(() => el.remove(), 700);
+    }, 4000);
+  };
+  ensure();
+}
+
+/**
+ * Supabase エラーを観測したらオフライン通知を出す。
+ * @param {unknown} err
+ * @param {string} [context]
+ */
+export function noticeSupabaseFailure(err, context = '') {
+  if (context) console.warn(`[offline] ${context}:`, err);
+  showOfflineNotice();
+}

--- a/src/js/pixelAssets.js
+++ b/src/js/pixelAssets.js
@@ -7,6 +7,7 @@
  * This is designed so future games can load by assetId.
  */
 import { supabase } from './supabaseClient.js';
+import { noticeSupabaseFailure } from './offline.js';
 
 const DB_NAME = 'n-games-assets';
 const DB_VERSION = 1;
@@ -258,20 +259,34 @@ export async function getPixelAsset(id) {
   if (localAsset) return localAsset;
 
   // Fallback: fetch from Supabase and cache locally.
-  const { data: meta, error: metaErr } = await supabase
-    .from('pixel_assets')
-    .select('id, owner_id, name, kind, width, height, created_at, updated_at, frame_count')
-    .eq('id', id)
-    .maybeSingle();
-  if (metaErr) throw metaErr;
+  let meta;
+  let frames;
+  try {
+    const { data, error } = await supabase
+      .from('pixel_assets')
+      .select('id, owner_id, name, kind, width, height, created_at, updated_at, frame_count')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    meta = data;
+  } catch (e) {
+    noticeSupabaseFailure(e, 'getPixelAsset/meta');
+    return null;
+  }
   if (!meta) return null;
 
-  const { data: frames, error: framesErr } = await supabase
-    .from('pixel_asset_frames')
-    .select('asset_id, frame_index, width, height, pixels_b64, duration_ms')
-    .eq('asset_id', id)
-    .order('frame_index', { ascending: true });
-  if (framesErr) throw framesErr;
+  try {
+    const { data, error } = await supabase
+      .from('pixel_asset_frames')
+      .select('asset_id, frame_index, width, height, pixels_b64, duration_ms')
+      .eq('asset_id', id)
+      .order('frame_index', { ascending: true });
+    if (error) throw error;
+    frames = data;
+  } catch (e) {
+    noticeSupabaseFailure(e, 'getPixelAsset/frames');
+    return null;
+  }
 
   const frame0 = (frames || []).find((f) => f.frame_index === 0) || frames?.[0];
   const pixels = frame0 ? base64ToPixels(frame0.pixels_b64) : createEmptyPixels(meta.width, meta.height);
@@ -305,17 +320,8 @@ export async function getPixelAsset(id) {
  * @param {{ownerId:string, kind?:PixelAssetKind}} params
  */
 export async function listPixelAssets({ ownerId, kind } = {}) {
-  // Prefer Supabase as source of truth, and cache locally.
-  let metaQuery = supabase
-    .from('pixel_assets')
-    .select('id, owner_id, name, kind, width, height, created_at, updated_at, frame_count')
-    .order('updated_at', { ascending: false });
-  if (ownerId) metaQuery = metaQuery.eq('owner_id', ownerId);
-  if (kind) metaQuery = metaQuery.eq('kind', kind);
-
-  const { data: metas, error: metaErr } = await metaQuery;
-  if (metaErr) {
-    // Fallback to local-only
+  // Local-first: load from IndexedDB so the app works offline.
+  async function readLocal() {
     const raws = await withStore('readonly', (store) => {
       if (ownerId && kind) {
         const index = store.index('ownerId_kind');
@@ -333,15 +339,40 @@ export async function listPixelAssets({ ownerId, kind } = {}) {
     return list;
   }
 
+  // Try Supabase as source of truth; on any failure, return the local list.
+  let metas;
+  try {
+    let metaQuery = supabase
+      .from('pixel_assets')
+      .select('id, owner_id, name, kind, width, height, created_at, updated_at, frame_count')
+      .order('updated_at', { ascending: false });
+    if (ownerId) metaQuery = metaQuery.eq('owner_id', ownerId);
+    if (kind) metaQuery = metaQuery.eq('kind', kind);
+
+    const { data, error } = await metaQuery;
+    if (error) throw error;
+    metas = data;
+  } catch (e) {
+    noticeSupabaseFailure(e, 'listPixelAssets/meta');
+    return readLocal();
+  }
+
   const ids = (metas || []).map((m) => m.id);
-  const { data: frames0, error: framesErr } = ids.length
-    ? await supabase
+  let frames0 = [];
+  try {
+    if (ids.length) {
+      const { data, error } = await supabase
         .from('pixel_asset_frames')
         .select('asset_id, frame_index, width, height, pixels_b64, duration_ms')
         .in('asset_id', ids)
-        .eq('frame_index', 0)
-    : { data: [], error: null };
-  if (framesErr) throw framesErr;
+        .eq('frame_index', 0);
+      if (error) throw error;
+      frames0 = data || [];
+    }
+  } catch (e) {
+    noticeSupabaseFailure(e, 'listPixelAssets/frames');
+    return readLocal();
+  }
 
   const frameMap = new Map((frames0 || []).map((f) => [f.asset_id, f]));
 

--- a/src/js/score.js
+++ b/src/js/score.js
@@ -1,44 +1,48 @@
 import { supabase } from './supabaseClient.js';
+import { appendLocalScore, localRankings, noticeSupabaseFailure } from './offline.js';
 
 export async function saveScore(gameId, playerId, score) {
-    const { data, error } = await supabase
-        .from('scores')
-        .insert([{ game_id: gameId, player_id: playerId, score }]);
+    // ローカルにも必ず残す。Supabase が落ちていてもランキングが見られるように。
+    appendLocalScore(gameId, playerId, score);
 
-    if (error) {
-        console.error('Error saving score:', error);
+    try {
+        const { error } = await supabase
+            .from('scores')
+            .insert([{ game_id: gameId, player_id: playerId, score }]);
+        if (error) throw error;
+        return true;
+    } catch (e) {
+        noticeSupabaseFailure(e, 'saveScore');
         return false;
     }
-    return true;
 }
 
 export async function getRankings(gameId, limit = 5) {
-    // Supabase can join tables!
-    // We select scores and join with players to get name and avatar.
-    const { data, error } = await supabase
-        .from('scores')
-        .select(`
-            score,
-            created_at,
-            players (
-                name,
-                avatar
-            )
-        `)
-        .eq('game_id', gameId)
-        .order('score', { ascending: false })
-        .limit(limit);
+    try {
+        const { data, error } = await supabase
+            .from('scores')
+            .select(`
+                score,
+                created_at,
+                players (
+                    name,
+                    avatar
+                )
+            `)
+            .eq('game_id', gameId)
+            .order('score', { ascending: false })
+            .limit(limit);
 
-    if (error) {
-        console.error('Error fetching rankings:', error);
-        return [];
+        if (error) throw error;
+
+        return data.map((item) => ({
+            score: item.score,
+            name: item.players?.name || 'プレイヤー',
+            avatar: item.players?.avatar || '❓',
+            date: new Date(item.created_at).toLocaleDateString()
+        }));
+    } catch (e) {
+        noticeSupabaseFailure(e, 'getRankings');
+        return localRankings(gameId, limit);
     }
-
-    // Flatten structure for easier usage
-    return data.map(item => ({
-        score: item.score,
-        name: item.players.name,
-        avatar: item.players.avatar || '❓', // Fallback
-        date: new Date(item.created_at).toLocaleDateString()
-    }));
 }

--- a/src/pages/select-player/select-player.js
+++ b/src/pages/select-player/select-player.js
@@ -4,6 +4,12 @@ import { isImageAvatar, makeImageAvatar, renderAvatarInto } from '../../js/avata
 import { pokemonData } from '../../data/pokemonData.js';
 import { assetPreviewDataUrl, listPixelAssets } from '../../js/pixelAssets.js';
 import { navigateTo } from '../../js/config.js';
+import {
+  loadLocalPlayers,
+  saveLocalPlayers,
+  genLocalId,
+  noticeSupabaseFailure
+} from '../../js/offline.js';
 
 requireAuth();
 
@@ -227,46 +233,91 @@ saveBtn.onclick = async () => {
 
 
 /* ================= API Logic ================= */
+// Supabase が使えない時のためにローカルにもプレイヤーを保存する。
+// オンラインなら Supabase をマスター、ローカルはミラー。
+// オフライン時はローカルだけで完結する。
+
+function mergePlayers(remote, local) {
+    const map = new Map();
+    (local || []).forEach((p) => p && p.id && map.set(p.id, p));
+    (remote || []).forEach((p) => p && p.id && map.set(p.id, p));
+    const list = Array.from(map.values());
+    list.sort((a, b) => {
+        const ta = a.created_at ? Date.parse(a.created_at) : 0;
+        const tb = b.created_at ? Date.parse(b.created_at) : 0;
+        return ta - tb;
+    });
+    return list;
+}
 
 async function fetchPlayers() {
-    const { data, error } = await supabase
-        .from('players')
-        .select('*')
-        .order('created_at', { ascending: true });
+    try {
+        const { data, error } = await supabase
+            .from('players')
+            .select('*')
+            .order('created_at', { ascending: true });
 
-    if (error) {
-        console.error('Error fetching players:', error);
-        return [];
+        if (error) throw error;
+        const merged = mergePlayers(data, loadLocalPlayers());
+        saveLocalPlayers(merged);
+        return merged;
+    } catch (e) {
+        noticeSupabaseFailure(e, 'fetchPlayers');
+        return loadLocalPlayers();
     }
-    return data;
 }
 
 async function addPlayer(name, avatar) {
-    const { error } = await supabase
-        .from('players')
-        .insert([{ name, avatar }]);
+    let saved = null;
+    try {
+        const { data, error } = await supabase
+            .from('players')
+            .insert([{ name, avatar }])
+            .select()
+            .single();
+        if (error) throw error;
+        saved = data;
+    } catch (e) {
+        noticeSupabaseFailure(e, 'addPlayer');
+    }
 
-    if (error) alert('追加できませんでした');
-    else renderPlayers();
+    const list = loadLocalPlayers();
+    const row = saved || { id: genLocalId(), name, avatar, created_at: new Date().toISOString() };
+    if (!list.some((p) => p.id === row.id)) list.push(row);
+    saveLocalPlayers(list);
+    renderPlayers();
 }
 
 async function updatePlayer(id, name, avatar) {
-    const { error } = await supabase
-        .from('players')
-        .update({ name, avatar })
-        .eq('id', id);
+    try {
+        const { error } = await supabase
+            .from('players')
+            .update({ name, avatar })
+            .eq('id', id);
+        if (error) throw error;
+    } catch (e) {
+        noticeSupabaseFailure(e, 'updatePlayer');
+    }
 
-    if (error) alert('更新できませんでした');
-    else renderPlayers();
+    const list = loadLocalPlayers().map((p) => (p.id === id ? { ...p, name, avatar } : p));
+    saveLocalPlayers(list);
+    renderPlayers();
 }
 
 async function deletePlayer(id, event) {
     event.stopPropagation();
     if (!confirm('本当に消しちゃう？')) return;
 
-    const { error } = await supabase.from('players').delete().eq('id', id);
-    if (error) alert('削除できませんでした');
-    else renderPlayers();
+    try {
+        const { error } = await supabase.from('players').delete().eq('id', id);
+        if (error) throw error;
+    } catch (e) {
+        noticeSupabaseFailure(e, 'deletePlayer');
+    }
+
+    const list = loadLocalPlayers().filter((p) => p.id !== id);
+    saveLocalPlayers(list);
+    renderPlayers();
 }
 
 async function renderPlayers() {


### PR DESCRIPTION
## 概要

Supabase プロジェクトが期限切れ／一時停止していると、ログイン後の「だれがあそぶ？」ページでプレイヤー一覧が取れず、その先のゲームに進めなくなっていた問題を修正します。
DB に依存しないゲームは、Supabase が死んでいてもオフラインで遊べるようになります。

## 変更点

- **`src/js/offline.js` を新規追加**: localStorage 上のプレイヤー/スコア保存ヘルパと、画面上に一度だけ出すオフライン通知バナーを共通化
- **`src/pages/select-player/select-player.js`**: プレイヤー一覧/追加/編集/削除を localStorage にミラー。Supabase 失敗時はローカルのみで完結。復活時はリモート＋ローカルをマージ
- **`src/js/score.js`**: スコアは必ずローカルに残す。ランキングはリモート優先、失敗時はローカル履歴から表示
- **`src/js/pixelAssets.js`**: 一覧/取得を Supabase 失敗時に IndexedDB のみで返すように整理（`framesErr throw` で全体クラッシュしてた経路をフォールバックに統一）

## 効果

- ログイン → プレイヤー選択 → ポータル → ゲーム の導線が DB 無しで通る
- DB を直接使うゲーム（maze / brick-breaker / math-battle 多人数）も、もともと localStorage キャッシュ＋try/catch があるので起動はする（編集の保存はオフライン時に失敗するが、デフォルト/既存ステージで遊べる）

## Test plan

- [ ] `npm run build` が通ること（ローカルで確認済み）
- [ ] Supabase が応答しない状況で `pages/login/login.html` → `pages/select-player/select-player.html` → ポータルへ遷移できる
- [ ] 「あたらしくつくる」でローカルにプレイヤーが作れて、ポータルに入れる
- [ ] スネーク等のスコア系ゲームで、ゲームオーバー後にローカルランキングが表示される
- [ ] ドット絵メーカーが既存の IndexedDB キャッシュからアセットを読める
- [ ] スマホ幅で「オフラインモードで動作中」バナーが画面外に飛び出さない

https://claude.ai/code/session_0157E3LBRhcJ81YQ5M6vTxue

---
_Generated by [Claude Code](https://claude.ai/code/session_0157E3LBRhcJ81YQ5M6vTxue)_