### PR TITLE
Add playable browser version of イキノコオリ (2–4 players)

### DIFF
--- a/src/games/ikinokoori/game.js
+++ b/src/games/ikinokoori/game.js
@@ -1,0 +1,100 @@
+const boardSize = 9;
+const colors = ["#ff7aa8", "#6ad1ff", "#ffd166", "#7ce38b"];
+const names = ["うさぎ", "ぺんぎん", "ねこ", "こぐま"];
+const icons = ["🐰", "🐧", "🐱", "🐻"];
+let players = [];
+let current = 0;
+let tiles = [];
+let particles = [];
+let over = false;
+
+const canvas = document.getElementById('board');
+const ctx = canvas.getContext('2d');
+const statusEl = document.getElementById('status');
+const panelEl = document.getElementById('playerPanel');
+const countEl = document.getElementById('playerCount');
+
+document.getElementById('resetBtn').onclick = init;
+countEl.onchange = init;
+canvas.addEventListener('pointerdown', onTap);
+
+const ac = new (window.AudioContext || window.webkitAudioContext)();
+const beep = (f = 440, d = 0.09) => {
+  const o = ac.createOscillator(), g = ac.createGain();
+  o.type = 'triangle'; o.frequency.value = f;
+  o.connect(g); g.connect(ac.destination); g.gain.value = 0.03;
+  o.start(); o.stop(ac.currentTime + d);
+};
+
+function init() {
+  over = false; particles = [];
+  tiles = Array.from({ length: boardSize }, () => Array(boardSize).fill(1));
+  const count = Number(countEl.value);
+  players = Array.from({ length: count }, (_, i) => ({ id: i, x: i % 2 ? boardSize - 1 : 0, y: i < 2 ? 0 : boardSize - 1, alive: true }));
+  current = 0;
+  draw(); renderPanel();
+  statusEl.textContent = `${icons[current]} ${names[current]} の番！近くのマスへ移動しよう`;
+}
+
+function onTap(e) {
+  if (over) return;
+  const p = players[current]; if (!p?.alive) return nextTurn();
+  const rect = canvas.getBoundingClientRect();
+  const s = rect.width / boardSize;
+  const x = Math.floor((e.clientX - rect.left) / s), y = Math.floor((e.clientY - rect.top) / s);
+  const dist = Math.abs(x - p.x) + Math.abs(y - p.y);
+  if (dist !== 1 || !tiles[y]?.[x]) return;
+  tiles[p.y][p.x] = 0;
+  spawn((p.x + .5) * s, (p.y + .5) * s, p.id);
+  p.x = x; p.y = y;
+  beep(520 + current * 80);
+  checkFalls();
+  nextTurn();
+}
+
+function checkFalls() {
+  for (const pl of players) {
+    if (!pl.alive) continue;
+    if (!tiles[pl.y][pl.x] || !hasMove(pl)) { pl.alive = false; beep(180, .2); }
+  }
+}
+
+function hasMove(pl) {
+  return [[1,0],[-1,0],[0,1],[0,-1]].some(([dx,dy]) => tiles[pl.y+dy]?.[pl.x+dx]);
+}
+
+function nextTurn() {
+  const alive = players.filter(p => p.alive);
+  if (alive.length <= 1) {
+    over = true;
+    statusEl.textContent = alive[0] ? `🎉 ${icons[alive[0].id]} ${names[alive[0].id]} の勝ち！` : 'みんな落ちちゃった！引き分け';
+    renderPanel(); draw();
+    return;
+  }
+  do { current = (current + 1) % players.length; } while (!players[current].alive);
+  statusEl.textContent = `${icons[current]} ${names[current]} の番！`;
+  renderPanel(); draw();
+}
+
+function renderPanel() {
+  panelEl.innerHTML = players.map((p, i) => `<div class="player-card ${i===current&&!over?'active':''} ${p.alive?'':'out'}" style="border-color:${p.alive?colors[i]:'transparent'}">${icons[i]} ${names[i]}<br>${p.alive?'生存中':'脱落'}</div>`).join('');
+}
+
+function spawn(x,y,id){ for(let i=0;i<16;i++) particles.push({x,y,vx:(Math.random()-.5)*3,vy:(Math.random()-.5)*3,life:30,c:colors[id]}); }
+function tick(){
+  const s = canvas.width / boardSize;
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  for(let y=0;y<boardSize;y++) for(let x=0;x<boardSize;x++){
+    if(!tiles[y][x]) continue;
+    ctx.fillStyle = (x+y)%2? '#c8f0ff' : '#dbf6ff';
+    roundRect(ctx, x*s+3,y*s+3,s-6,s-6,12); ctx.fill();
+  }
+  players.forEach((p,i)=>{ if(!p.alive)return; ctx.fillStyle=colors[i]; ctx.beginPath(); ctx.arc((p.x+.5)*s,(p.y+.5)*s,s*.28,0,7); ctx.fill(); ctx.font=`${s*.32}px sans-serif`; ctx.textAlign='center'; ctx.fillText(icons[i],(p.x+.5)*s,(p.y+.6)*s); });
+  particles = particles.filter(p=>(p.x+=p.vx,p.y+=p.vy,p.life--)>0);
+  for(const p of particles){ ctx.globalAlpha=p.life/30; ctx.fillStyle=p.c; ctx.fillRect(p.x,p.y,5,5); }
+  ctx.globalAlpha = 1;
+  requestAnimationFrame(tick);
+}
+function draw(){ }
+function roundRect(c,x,y,w,h,r){ c.beginPath(); c.moveTo(x+r,y); c.arcTo(x+w,y,x+w,y+h,r); c.arcTo(x+w,y+h,x,y+h,r); c.arcTo(x,y+h,x,y,r); c.arcTo(x,y,x+w,y,r); c.closePath(); }
+init(); tick();

--- a/src/games/ikinokoori/index.html
+++ b/src/games/ikinokoori/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+  <title>イキノコオリ</title>
+  <link rel="stylesheet" href="./style.css" />
+</head>
+<body>
+  <main class="app">
+    <header class="topbar">
+      <h1>❄️ イキノコオリ</h1>
+      <div class="controls">
+        <label>人数
+          <select id="playerCount">
+            <option value="2">2人</option>
+            <option value="3">3人</option>
+            <option value="4" selected>4人</option>
+          </select>
+        </label>
+        <button id="resetBtn">あたらしく遊ぶ</button>
+      </div>
+    </header>
+    <section class="status" id="status"></section>
+    <section id="playerPanel" class="player-panel"></section>
+    <section class="board-wrap">
+      <canvas id="board" width="900" height="900"></canvas>
+      <div class="hint">タップで移動 → 足場が割れて消える！最後まで生き残れ！</div>
+    </section>
+  </main>
+  <script type="module" src="./game.js"></script>
+</body>
+</html>

--- a/src/games/ikinokoori/style.css
+++ b/src/games/ikinokoori/style.css
@@ -1,0 +1,17 @@
+:root { font-family: "M PLUS Rounded 1c", "Hiragino Maru Gothic ProN", sans-serif; color-scheme: light; }
+body { margin:0; background: radial-gradient(circle at top, #e8f8ff, #b6dfff 50%, #87c7f5); min-height:100vh; }
+.app{ max-width:1100px; margin:0 auto; padding:12px; }
+.topbar{ display:flex; flex-wrap:wrap; justify-content:space-between; gap:10px; align-items:center; }
+h1{ margin:0; color:#155b9a; }
+.controls{ display:flex; gap:8px; align-items:center; }
+select,button{ border:none; border-radius:999px; padding:10px 14px; font-size:16px; }
+button{ background:#ff7bb1; color:white; font-weight:700; }
+.status{ margin:12px 0; background:#ffffffd8; padding:10px 14px; border-radius:14px; font-size:18px; color:#0f3e69; }
+.player-panel{ display:grid; grid-template-columns:repeat(4,minmax(0,1fr)); gap:8px; }
+.player-card{ background:#ffffffd6; border-radius:12px; padding:8px; text-align:center; border:3px solid transparent; font-size:14px; }
+.player-card.active{ border-color:#ffcf5f; transform:translateY(-2px); }
+.player-card.out{ opacity:.45; filter:grayscale(.8); }
+.board-wrap{ margin-top:10px; }
+#board{ width:min(94vw,760px); height:min(94vw,760px); max-height:75vh; display:block; margin:0 auto; border-radius:22px; box-shadow:0 10px 25px #0b4c7d44; touch-action:manipulation; background:#e0f5ff; }
+.hint{ text-align:center; margin-top:8px; color:#0c4472; font-weight:700; }
+@media (max-width:900px){ .player-panel{ grid-template-columns:repeat(2,minmax(0,1fr)); } .status{font-size:16px;} }

--- a/src/pages/portal/portal.js
+++ b/src/pages/portal/portal.js
@@ -358,6 +358,14 @@ const games = [
     color: '#1a1a2e',
     icon: '⛩️',
     link: '/games/kakuriyo/'
+  },
+  {
+    id: 'ikinokoori',
+    title: 'イキノコオリ',
+    desc: '2〜4人でバトル！氷の床を渡って最後の1人になろう❄️',
+    color: '#7dd3fc',
+    icon: '❄️',
+    link: '/games/ikinokoori/'
   }
 ];
 


### PR DESCRIPTION
### Motivation
- Provide a browser-playable local multiplayer implementation of the real-world game イキノコオリ so players can play on tablets and desktops. 
- Make the UI touch/tablet-friendly with a clear turn/status panel and large controls for 2–4 players. 
- Deliver a lightweight, deployable game that integrates into the existing portal so it can be launched from the game list. 

### Description
- Added a new game under `src/games/ikinokoori/` with `index.html`, `style.css`, and `game.js` implementing the core rules: players move to adjacent tiles, the previous tile disappears, and the last alive player wins. 
- Implemented touch-friendly input via `pointerdown`, a responsive board canvas, tablet-first layout, player cards, status text, and a player-count selector in `index.html` and `style.css`. 
- Added lightweight particle effects and simple synthesized sound effects using the Web Audio API in `game.js` for moves and eliminations. 
- Exposed the game in the portal by updating `src/pages/portal/portal.js` to include the `ikinokoori` entry so it appears in the game list. 

### Testing
- Ran a production build with `npm run build` and the build completed successfully with no errors. 
- The new files `src/games/ikinokoori/index.html`, `src/games/ikinokoori/style.css`, and `src/games/ikinokoori/game.js` were added and the portal file `src/pages/portal/portal.js` was updated and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f712d468c48321803e278d4e8cf127)